### PR TITLE
Implement Hash on Sids

### DIFF
--- a/src/localheap.rs
+++ b/src/localheap.rs
@@ -1,6 +1,7 @@
 //! A specialized [`Box`] variation for items stored on the local heap.
 
 use crate::constants::LocalAllocFlags;
+use std::borrow::{Borrow, BorrowMut};
 use std::cmp::PartialEq;
 use std::fmt;
 use std::hash::Hash;
@@ -160,6 +161,18 @@ where
 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.deref().hash(state)
+    }
+}
+
+impl<T> Borrow<T> for LocalBox<T> {
+    fn borrow(&self) -> &T {
+        self.deref()
+    }
+}
+
+impl<T> BorrowMut<T> for LocalBox<T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        self.deref_mut()
     }
 }
 

--- a/src/localheap.rs
+++ b/src/localheap.rs
@@ -3,6 +3,7 @@
 use crate::constants::LocalAllocFlags;
 use std::cmp::PartialEq;
 use std::fmt;
+use std::hash::Hash;
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::ptr::{null_mut, NonNull};
@@ -153,6 +154,16 @@ impl<T: fmt::Debug> fmt::Debug for LocalBox<T> {
     }
 }
 
+impl<T> Hash for LocalBox<T>
+where
+    T: Hash
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.deref().hash(state)
+    }
+}
+
+impl<T> Eq for LocalBox<T> where T: Eq {}
 impl<T, U> PartialEq<LocalBox<U>> for LocalBox<T>
 where
     T: PartialEq<U>,

--- a/src/structures/sid.rs
+++ b/src/structures/sid.rs
@@ -1,4 +1,5 @@
 use crate::{wrappers, LocalBox};
+use std::hash::Hash;
 use std::fmt;
 use std::io;
 use std::str::FromStr;
@@ -198,6 +199,15 @@ impl fmt::Display for Sid {
     }
 }
 
+impl Hash for Sid {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id_authority().hash(state);
+        for index in 0..self.sub_authority_count() {
+            self.sub_authority(index).expect("Already checked count").hash(state);
+        }
+    }
+}
+
 impl FromStr for LocalBox<Sid> {
     type Err = io::Error;
 
@@ -206,6 +216,7 @@ impl FromStr for LocalBox<Sid> {
     }
 }
 
+impl Eq for Sid {}
 impl PartialEq for Sid {
     fn eq(&self, other: &Sid) -> bool {
         wrappers::EqualSid(self, other)


### PR DESCRIPTION
Implements Hash on Sid and LocalBox, which allows storing them within `HashMap`/`HashSet`.