### PR TITLE
impl Clone for LocalBox<Sid>

### DIFF
--- a/src/structures/sid.rs
+++ b/src/structures/sid.rs
@@ -225,6 +225,15 @@ impl PartialEq for Sid {
     }
 }
 
+impl Clone for LocalBox<Sid> {
+    fn clone(&self) -> Self {
+        wrappers::CopySid(self)
+        // internally, CopySid is just memmove with a length check.
+        // This cannot panic unless allocation fails.
+            .expect("Failed to clone SID")
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
CopySid internally is just

```C
NTSTATUS __stdcall RtlCopySid(ULONG DestinationSidLength, PSID DestinationSid, PSID SourceSid)
{
  ULONG v3; // eax

  v3 = 4 * *((unsigned __int8 *)SourceSid + 1) + 8;
  if ( v3 > DestinationSidLength )
    return 0xC0000023;
  memmove(DestinationSid, SourceSid, v3);
  return 0;
}
```

Which means it cannot fail as long as we pass it a valid `DestinationSidLength`, which we do in  `wrappers::CopySid` since we always use `GetSidLengthRequired`. 

The only ways for `wrappers::CopySid` to return an error is if the allocation of the `LocalBox` failed, in which case panicking in `.clone()` is a valid behavior. 