### PR TITLE
Migrating from winapi to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,16 @@ license = "MIT"
 targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
 
 [dependencies]
-winapi = { version = "0.3.9", features = [
-    "std",
-    "aclapi",
-    "handleapi",
-    "sddl",
-    "securitybaseapi",
-    "winerror",
-    "winnt",
-    ]}
+windows-sys = { version = "0.48", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Memory",
+    "Win32_System_Registry",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_Storage_FileSystem",
+]}
 bitflags = "1"
 
 [dev-dependencies]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,9 +3,16 @@
 #![allow(non_upper_case_globals)]
 #![allow(missing_docs)]
 
-use winapi::um::accctrl::*;
-use winapi::um::minwinbase::*;
-use winapi::um::winnt::*;
+use windows_sys::Win32::Foundation::GENERIC_ALL;
+use windows_sys::Win32::Foundation::GENERIC_EXECUTE;
+use windows_sys::Win32::Foundation::GENERIC_READ;
+use windows_sys::Win32::Foundation::GENERIC_WRITE;
+use windows_sys::Win32::Security::Authorization::*;
+use windows_sys::Win32::Security::*;
+use windows_sys::Win32::Storage::FileSystem::*;
+use windows_sys::Win32::System::Memory::*;
+use windows_sys::Win32::System::Registry::*;
+use windows_sys::Win32::System::SystemServices::*;
 
 /// Create an enum from a list of constants. Generated enums get a method
 /// `from_raw` that allows them to be converted from a value.
@@ -39,7 +46,7 @@ macro_rules! constant_enum {
     }
 }
 
-constant_enum!(TrusteeForm; u32;
+constant_enum!(TrusteeForm; i32;
     msdn: "https://docs.microsoft.com/en-us/windows/win32/api/accctrl/ne-accctrl-trustee_form";
     TRUSTEE_IS_SID,
     TRUSTEE_IS_NAME,
@@ -47,7 +54,7 @@ constant_enum!(TrusteeForm; u32;
     TRUSTEE_IS_OBJECTS_AND_SID,
     TRUSTEE_IS_OBJECTS_AND_NAME);
 
-constant_enum!(TrusteeType; u32;
+constant_enum!(TrusteeType; i32;
     msdn: "https://docs.microsoft.com/en-us/windows/win32/api/accctrl/ne-accctrl-trustee_type";
     TRUSTEE_IS_UNKNOWN,
     TRUSTEE_IS_USER,
@@ -59,12 +66,12 @@ constant_enum!(TrusteeType; u32;
     TRUSTEE_IS_INVALID,
     TRUSTEE_IS_COMPUTER);
 
-constant_enum!(MultipleTrusteeOperation; u32;
+constant_enum!(MultipleTrusteeOperation; i32;
     msdn: "https://docs.microsoft.com/en-us/windows/win32/api/accctrl/ne-accctrl-multiple_trustee_operation";
     NO_MULTIPLE_TRUSTEE,
     TRUSTEE_IS_IMPERSONATE);
 
-constant_enum!(SeObjectType; u32;
+constant_enum!(SeObjectType; i32;
     msdn: "https://docs.microsoft.com/en-us/windows/win32/api/accctrl/ne-accctrl-se_object_type";
     SE_UNKNOWN_OBJECT_TYPE,
     SE_FILE_OBJECT,
@@ -81,7 +88,7 @@ constant_enum!(SeObjectType; u32;
     SE_REGISTRY_WOW64_32KEY,
     SE_REGISTRY_WOW64_64KEY);
 
-constant_enum!(AceType; u8;
+constant_enum!(AceType; u32;
     msdn: "https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-ace_header#members";
     ACCESS_ALLOWED_ACE_TYPE,
     ACCESS_ALLOWED_CALLBACK_ACE_TYPE,
@@ -99,12 +106,12 @@ constant_enum!(AceType; u8;
     SYSTEM_RESOURCE_ATTRIBUTE_ACE_TYPE,
     SYSTEM_SCOPED_POLICY_ID_ACE_TYPE);
 
-constant_enum!(AclRevision; u8;
+constant_enum!(AclRevision; u32;
     msdn: "https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-acl";
     ACL_REVISION,
     ACL_REVISION_DS);
 
-constant_enum!(SidNameUse; u32;
+constant_enum!(SidNameUse; i32;
     msdn: "https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-sid_name_use";
     SidTypeUser,
     SidTypeGroup,
@@ -121,13 +128,13 @@ constant_enum!(SidNameUse; u32;
 bitflags! {
     /// See the `AceFlags` available at [MSDN](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-ace_header).
     pub struct AceFlags: u8 {
-        const ContainerInherit = CONTAINER_INHERIT_ACE;
-        const ObjectInherit = OBJECT_INHERIT_ACE;
-        const NoPropagateInherit = NO_PROPAGATE_INHERIT_ACE;
-        const InheritOnly = INHERIT_ONLY_ACE;
-        const Inherited = INHERITED_ACE;
-        const SuccessfulAccess = SUCCESSFUL_ACCESS_ACE_FLAG;
-        const FailedAccess = FAILED_ACCESS_ACE_FLAG;
+        const ContainerInherit = CONTAINER_INHERIT_ACE as u8;
+        const ObjectInherit = OBJECT_INHERIT_ACE as u8;
+        const NoPropagateInherit = NO_PROPAGATE_INHERIT_ACE as u8;
+        const InheritOnly = INHERIT_ONLY_ACE as u8;
+        const Inherited = INHERITED_ACE as u8;
+        const SuccessfulAccess = SUCCESSFUL_ACCESS_ACE_FLAG as u8;
+        const FailedAccess = FAILED_ACCESS_ACE_FLAG as u8;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 
 #[macro_use]
 extern crate bitflags;
-extern crate winapi;
+extern crate windows_sys;
 
 #[cfg(target_os = "windows")]
 pub mod constants;

--- a/src/localheap.rs
+++ b/src/localheap.rs
@@ -127,7 +127,7 @@ impl<T> Drop for LocalBox<T> {
 
 impl<T> AsRef<T> for LocalBox<T> {
     fn as_ref(&self) -> &T {
-        &*self
+        self
     }
 }
 

--- a/src/structures/acl.rs
+++ b/src/structures/acl.rs
@@ -1,8 +1,9 @@
+use windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER;
+use windows_sys::Win32::Security::ACL;
+
 use crate::{constants, wrappers, Ace, Trustee};
 use std::fmt;
 use std::io;
-use winapi::shared::winerror::ERROR_INVALID_PARAMETER;
-use winapi::um::winnt::ACL;
 
 /// An entry in an access control list (ACL).
 #[repr(C)]
@@ -105,7 +106,7 @@ impl Acl {
     /// assert_eq!(complex_acl_sd.dacl().unwrap().revision_level(), ACL_REVISION_DS);
     /// ```
     pub fn revision_level(&self) -> constants::AclRevision {
-        constants::AclRevision::from_raw(self.internal_type_reference().AclRevision)
+        constants::AclRevision::from_raw(self.internal_type_reference().AclRevision as u32)
             .expect("Unknown revision level")
     }
 }

--- a/src/structures/sid.rs
+++ b/src/structures/sid.rs
@@ -192,7 +192,7 @@ impl fmt::Display for Sid {
         write!(
             fmt,
             "{}",
-            wrappers::ConvertSidToStringSid(&self)
+            wrappers::ConvertSidToStringSid(self)
                 .expect("Passed a safe Sid to ConvertSidToStringSid but got an error")
                 .to_string_lossy()
         )

--- a/src/structures/sid.rs
+++ b/src/structures/sid.rs
@@ -44,14 +44,14 @@ impl Sid {
     ///
     /// ```
     /// use windows_permissions::{Sid, LocalBox};
-    /// use winapi::um::winnt::WinWorldSid;
+    /// use windows_sys::Win32::Security::WinWorldSid;
     ///
     /// let win_world_sid = Sid::well_known_sid(WinWorldSid).unwrap();
     /// let another_sid = "S-1-1-0".parse().unwrap();
     ///
     /// assert_eq!(win_world_sid, another_sid);
     /// ```
-    pub fn well_known_sid(well_known_sid_type: u32) -> io::Result<LocalBox<Sid>> {
+    pub fn well_known_sid(well_known_sid_type: i32) -> io::Result<LocalBox<Sid>> {
         wrappers::CreateWellKnownSid(well_known_sid_type, None)
     }
 

--- a/src/structures/trustee.rs
+++ b/src/structures/trustee.rs
@@ -73,7 +73,7 @@ impl<'s> Trustee<'s> {
     ///
     /// Also panics if the pointer value is null.
     pub fn get_subject(&self) -> TrusteeSubject<'s> {
-        let form = wrappers::GetTrusteeForm(&self)
+        let form = wrappers::GetTrusteeForm(self)
             .unwrap_or_else(|f| panic!("Trustee had unrecognized form: {:x}", f));
 
         let ptr = self.inner.ptstrName as *mut _;

--- a/src/structures/trustee.rs
+++ b/src/structures/trustee.rs
@@ -1,13 +1,13 @@
+use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
+
 use crate::constants::TrusteeForm;
 use crate::utilities;
 use crate::wrappers;
 use crate::Sid;
-use std::ffi::OsStr;
+use std::ffi::{c_void, OsStr};
 use std::fmt;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
-use winapi::ctypes::c_void;
-use winapi::um::accctrl::TRUSTEE_W;
 
 /// An entity that can be added to an ACL.
 ///

--- a/src/wrappers/add_ace.rs
+++ b/src/wrappers/add_ace.rs
@@ -8,9 +8,9 @@ use std::io;
 #[allow(non_snake_case)]
 pub fn AddAce(acl: &mut Acl, index: u32, ace: &Ace) -> io::Result<()> {
     let result = unsafe {
-        winapi::um::securitybaseapi::AddAce(
+        windows_sys::Win32::Security::AddAce(
             acl as *mut _ as *mut _,
-            winapi::um::winnt::ACL_REVISION_DS as u32, // Only handles new-style ACLs
+            windows_sys::Win32::Security::ACL_REVISION_DS,
             index,
             ace as *const _ as *mut _,
             1, // Just one in the list

--- a/src/wrappers/allocate_and_initialize_sid.rs
+++ b/src/wrappers/allocate_and_initialize_sid.rs
@@ -60,8 +60,8 @@ pub fn AllocateAndInitializeSid(id_auth: [u8; 6], sub_auths: &[u32]) -> io::Resu
     let sa_7 = if sub_auths.len() > 7 { sub_auths[7] } else { 0 };
 
     let result = unsafe {
-        winapi::um::securitybaseapi::AllocateAndInitializeSid(
-            &mut winapi::um::winnt::SID_IDENTIFIER_AUTHORITY { Value: id_auth },
+        windows_sys::Win32::Security::AllocateAndInitializeSid(
+            &mut windows_sys::Win32::Security::SID_IDENTIFIER_AUTHORITY { Value: id_auth },
             sub_auths.len() as u8,
             sa_0,
             sa_1,

--- a/src/wrappers/allocate_and_initialize_sid.rs
+++ b/src/wrappers/allocate_and_initialize_sid.rs
@@ -61,7 +61,7 @@ pub fn AllocateAndInitializeSid(id_auth: [u8; 6], sub_auths: &[u32]) -> io::Resu
 
     let result = unsafe {
         windows_sys::Win32::Security::AllocateAndInitializeSid(
-            &mut windows_sys::Win32::Security::SID_IDENTIFIER_AUTHORITY { Value: id_auth },
+            &windows_sys::Win32::Security::SID_IDENTIFIER_AUTHORITY { Value: id_auth },
             sub_auths.len() as u8,
             sa_0,
             sa_1,

--- a/src/wrappers/build_trustee_with_name.rs
+++ b/src/wrappers/build_trustee_with_name.rs
@@ -9,7 +9,7 @@ pub fn BuildTrusteeWithName<'s>(name_buf: &'s [u16]) -> Trustee<'s> {
     let mut trustee = unsafe { Trustee::allocate() };
 
     unsafe {
-        winapi::um::aclapi::BuildTrusteeWithNameW(
+        windows_sys::Win32::Security::Authorization::BuildTrusteeWithNameW(
             trustee.as_mut_ptr(),
             name_buf.as_ptr() as *mut _,
         );

--- a/src/wrappers/build_trustee_with_name.rs
+++ b/src/wrappers/build_trustee_with_name.rs
@@ -24,5 +24,5 @@ pub fn BuildTrusteeWithNameOsStr(name: &OsStr) -> Trustee<'static> {
     // Convert name into a static WTF-16 buffer
     let buffer: &'static [u16] = Box::leak(utilities::buf_from_os(name).into_boxed_slice());
 
-    BuildTrusteeWithName(&buffer)
+    BuildTrusteeWithName(buffer)
 }

--- a/src/wrappers/build_trustee_with_sid.rs
+++ b/src/wrappers/build_trustee_with_sid.rs
@@ -8,7 +8,10 @@ pub fn BuildTrusteeWithSid<'s>(sid: &'s Sid) -> Trustee<'s> {
     let mut trustee = unsafe { Trustee::allocate() };
 
     unsafe {
-        winapi::um::aclapi::BuildTrusteeWithSidW(trustee.as_mut_ptr(), sid as *const _ as *mut _)
+        windows_sys::Win32::Security::Authorization::BuildTrusteeWithSidW(
+            trustee.as_mut_ptr(),
+            sid as *const _ as *mut _,
+        )
     }
 
     trustee

--- a/src/wrappers/convert_security_descriptor_to_string_security_descriptor.rs
+++ b/src/wrappers/convert_security_descriptor_to_string_security_descriptor.rs
@@ -37,9 +37,9 @@ pub fn ConvertSecurityDescriptorToStringSecurityDescriptor(
 
     // If success, buf_ptr must be LocalFree'd
     let result = unsafe {
-        winapi::shared::sddl::ConvertSecurityDescriptorToStringSecurityDescriptorW(
+        windows_sys::Win32::Security::Authorization::ConvertSecurityDescriptorToStringSecurityDescriptorW(
             sd as *const _ as *mut _,
-            winapi::shared::sddl::SDDL_REVISION_1.into(),
+            windows_sys::Win32::Security::Authorization::SDDL_REVISION_1.into(),
             info.bits(),
             &mut buf_ptr,
             &mut buf_len,
@@ -55,7 +55,7 @@ pub fn ConvertSecurityDescriptorToStringSecurityDescriptor(
 
     let string = utilities::os_from_buf(slice);
 
-    unsafe { winapi::um::winbase::LocalFree(buf_ptr as *mut _) };
+    unsafe { windows_sys::Win32::System::Memory::LocalFree(buf_ptr as *mut _ as isize) };
 
     Ok(string)
 }

--- a/src/wrappers/convert_security_descriptor_to_string_security_descriptor.rs
+++ b/src/wrappers/convert_security_descriptor_to_string_security_descriptor.rs
@@ -39,7 +39,7 @@ pub fn ConvertSecurityDescriptorToStringSecurityDescriptor(
     let result = unsafe {
         windows_sys::Win32::Security::Authorization::ConvertSecurityDescriptorToStringSecurityDescriptorW(
             sd as *const _ as *mut _,
-            windows_sys::Win32::Security::Authorization::SDDL_REVISION_1.into(),
+            windows_sys::Win32::Security::Authorization::SDDL_REVISION_1,
             info.bits(),
             &mut buf_ptr,
             &mut buf_len,

--- a/src/wrappers/convert_sid_to_string_sid.rs
+++ b/src/wrappers/convert_sid_to_string_sid.rs
@@ -19,7 +19,10 @@ use std::ptr::null_mut;
 pub fn ConvertSidToStringSid(sid: &Sid) -> io::Result<OsString> {
     let mut buf_ptr: *mut u16 = null_mut();
     let result = unsafe {
-        winapi::shared::sddl::ConvertSidToStringSidW(sid as *const _ as *mut _, &mut buf_ptr)
+        windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW(
+            sid as *const _ as *mut _,
+            &mut buf_ptr,
+        )
     };
 
     if result == 0 {
@@ -32,7 +35,7 @@ pub fn ConvertSidToStringSid(sid: &Sid) -> io::Result<OsString> {
 
         let os_string = utilities::os_from_buf(slice_with_nul);
 
-        unsafe { winapi::um::winbase::LocalFree(buf_ptr as *mut _) };
+        unsafe { windows_sys::Win32::System::Memory::LocalFree(buf_ptr as isize) };
 
         Ok(os_string)
     }

--- a/src/wrappers/convert_string_security_descriptor_to_security_descriptor.rs
+++ b/src/wrappers/convert_string_security_descriptor_to_security_descriptor.rs
@@ -26,9 +26,9 @@ pub fn ConvertStringSecurityDescriptorToSecurityDescriptor<S: AsRef<OsStr> + ?Si
     let mut sd_ptr = null_mut();
 
     let result = unsafe {
-        winapi::shared::sddl::ConvertStringSecurityDescriptorToSecurityDescriptorW(
+        windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW(
             buffer.as_ptr(),
-            winapi::shared::sddl::SDDL_REVISION_1.into(),
+            windows_sys::Win32::Security::Authorization::SDDL_REVISION_1.into(),
             &mut sd_ptr,
             null_mut(),
         )

--- a/src/wrappers/convert_string_security_descriptor_to_security_descriptor.rs
+++ b/src/wrappers/convert_string_security_descriptor_to_security_descriptor.rs
@@ -28,7 +28,7 @@ pub fn ConvertStringSecurityDescriptorToSecurityDescriptor<S: AsRef<OsStr> + ?Si
     let result = unsafe {
         windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW(
             buffer.as_ptr(),
-            windows_sys::Win32::Security::Authorization::SDDL_REVISION_1.into(),
+            windows_sys::Win32::Security::Authorization::SDDL_REVISION_1,
             &mut sd_ptr,
             null_mut(),
         )

--- a/src/wrappers/convert_string_sid_to_sid.rs
+++ b/src/wrappers/convert_string_sid_to_sid.rs
@@ -23,7 +23,9 @@ pub fn ConvertStringSidToSid<S: AsRef<OsStr> + ?Sized>(string: &S) -> io::Result
     let buf = buf_from_os(string);
     let mut ptr = null_mut();
 
-    let result = unsafe { winapi::shared::sddl::ConvertStringSidToSidW(buf.as_ptr(), &mut ptr) };
+    let result = unsafe {
+        windows_sys::Win32::Security::Authorization::ConvertStringSidToSidW(buf.as_ptr(), &mut ptr)
+    };
 
     if result != 0 {
         // Success

--- a/src/wrappers/copy_sid.rs
+++ b/src/wrappers/copy_sid.rs
@@ -8,7 +8,7 @@ use std::io;
 ///
 /// ```
 /// use windows_permissions::{wrappers::CopySid, Sid};
-/// use winapi::um::winnt::WinBuiltinAdministratorsSid;
+/// use windows_sys::Win32::Security::WinBuiltinAdministratorsSid;
 ///
 /// let original = Sid::well_known_sid(WinBuiltinAdministratorsSid).unwrap();
 ///
@@ -27,7 +27,7 @@ pub fn CopySid(sid: &Sid) -> io::Result<LocalBox<Sid>> {
     let new_sid: LocalBox<Sid> = unsafe { LocalBox::try_allocate(true, size)? };
 
     let success = unsafe {
-        winapi::um::securitybaseapi::CopySid(
+        windows_sys::Win32::Security::CopySid(
             size as u32,
             new_sid.as_ptr() as *mut _,
             sid as *const _ as *mut _,

--- a/src/wrappers/create_well_known_sid.rs
+++ b/src/wrappers/create_well_known_sid.rs
@@ -11,7 +11,7 @@ use std::ptr::null_mut;
 ///
 /// ```
 /// use windows_permissions::{wrappers, Sid, LocalBox};
-/// use winapi::um::winnt::WinWorldSid;
+/// use windows_sys::Win32::Security::WinWorldSid;
 ///
 /// let win_world_sid = wrappers::CreateWellKnownSid(WinWorldSid, None).unwrap();
 /// let another_sid = "S-1-1-0".parse().unwrap();
@@ -19,7 +19,7 @@ use std::ptr::null_mut;
 /// assert_eq!(win_world_sid, another_sid);
 /// ```
 #[allow(non_snake_case)]
-pub fn CreateWellKnownSid(sid_type: u32, domain_sid: Option<&Sid>) -> io::Result<LocalBox<Sid>> {
+pub fn CreateWellKnownSid(sid_type: i32, domain_sid: Option<&Sid>) -> io::Result<LocalBox<Sid>> {
     // Optimistically reserve enough space for a fairly large SID
     let mut sid_len = wrappers::GetSidLengthRequired(8) as u32;
 
@@ -33,7 +33,7 @@ pub fn CreateWellKnownSid(sid_type: u32, domain_sid: Option<&Sid>) -> io::Result
     let new_sid: LocalBox<Sid> = unsafe { LocalBox::try_allocate(true, sid_len as usize)? };
 
     let result = unsafe {
-        winapi::um::securitybaseapi::CreateWellKnownSid(
+        windows_sys::Win32::Security::CreateWellKnownSid(
             sid_type,
             domain_sid_ptr,
             new_sid.as_ptr() as *mut _,

--- a/src/wrappers/equal_sid.rs
+++ b/src/wrappers/equal_sid.rs
@@ -7,7 +7,7 @@ use crate::Sid;
 ///
 /// ```
 /// use windows_permissions::{Sid, LocalBox, wrappers::EqualSid};
-/// use winapi::um::winnt::WinCreatorGroupSid;
+/// use windows_sys::Win32::Security::WinCreatorGroupSid;
 ///
 /// let sid1: LocalBox<Sid> = "S-1-3-1".parse().unwrap();
 /// let sid2 = Sid::well_known_sid(WinCreatorGroupSid).unwrap();
@@ -20,7 +20,7 @@ use crate::Sid;
 #[allow(non_snake_case)]
 pub fn EqualSid(sid1: &Sid, sid2: &Sid) -> bool {
     (unsafe {
-        winapi::um::securitybaseapi::EqualSid(
+        windows_sys::Win32::Security::EqualSid(
             sid1 as *const _ as *mut _,
             sid2 as *const _ as *mut _,
         )

--- a/src/wrappers/get_ace.rs
+++ b/src/wrappers/get_ace.rs
@@ -15,7 +15,7 @@ pub fn GetAce(acl: &Acl, index: u32) -> io::Result<&Ace> {
     let mut ace = null_mut();
 
     let result =
-        unsafe { winapi::um::securitybaseapi::GetAce(acl as *const _ as *mut _, index, &mut ace) };
+        unsafe { windows_sys::Win32::Security::GetAce(acl as *const _ as *mut _, index, &mut ace) };
 
     if result == 0 {
         // Failed

--- a/src/wrappers/get_acl_information.rs
+++ b/src/wrappers/get_acl_information.rs
@@ -1,6 +1,7 @@
+use windows_sys::Win32::Security::ACL_SIZE_INFORMATION;
+
 use crate::Acl;
 use std::io;
-use winapi::um::winnt::ACL_SIZE_INFORMATION;
 
 /// Wraps [`GetAclInformation`](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-getaclinformation)
 ///
@@ -18,11 +19,11 @@ pub fn GetAclInformationSize(acl: &Acl) -> io::Result<ACL_SIZE_INFORMATION> {
     let info_size = std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32;
 
     let result = unsafe {
-        winapi::um::securitybaseapi::GetAclInformation(
+        windows_sys::Win32::Security::GetAclInformation(
             acl as *const _ as *mut _,
             &mut info as *mut _ as *mut _,
             info_size,
-            winapi::um::winnt::AclSizeInformation,
+            windows_sys::Win32::Security::AclSizeInformation,
         )
     };
 

--- a/src/wrappers/get_effective_rights_from_acl.rs
+++ b/src/wrappers/get_effective_rights_from_acl.rs
@@ -9,14 +9,14 @@ pub fn GetEffectiveRightsFromAcl(acl: &Acl, trustee: &Trustee) -> Result<AccessR
     let mut acc_mask = 0u32;
 
     let result = unsafe {
-        winapi::um::aclapi::GetEffectiveRightsFromAclW(
+        windows_sys::Win32::Security::Authorization::GetEffectiveRightsFromAclW(
             acl as *const _ as *mut _,
             trustee as *const _ as *mut _,
             &mut acc_mask,
         )
     };
 
-    if result == winapi::shared::winerror::ERROR_SUCCESS {
+    if result == windows_sys::Win32::Foundation::ERROR_SUCCESS {
         Ok(AccessRights::from_bits_truncate(acc_mask))
     } else {
         Err(io::Error::from_raw_os_error(result as i32))

--- a/src/wrappers/get_named_security_info.rs
+++ b/src/wrappers/get_named_security_info.rs
@@ -1,10 +1,11 @@
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+
 use crate::constants::{SeObjectType, SecurityInformation};
 use crate::utilities::buf_from_os;
 use crate::{LocalBox, SecurityDescriptor};
 use std::ffi::OsStr;
 use std::io;
 use std::ptr::{null_mut, NonNull};
-use winapi::shared::winerror::ERROR_SUCCESS;
 
 /// Wraps [`GetNamedSecurityInfoW`](https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-getnamedsecurityinfow)
 ///
@@ -22,9 +23,9 @@ pub fn GetNamedSecurityInfo<S: AsRef<OsStr> + ?Sized>(
     let mut sd = null_mut();
 
     let result_code = unsafe {
-        winapi::um::aclapi::GetNamedSecurityInfoW(
+        windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW(
             name.as_ptr(),
-            obj_type as u32,
+            obj_type as _,
             sec_info.bits(),
             null_mut(),
             null_mut(),

--- a/src/wrappers/get_security_descriptor_dacl_sacl.rs
+++ b/src/wrappers/get_security_descriptor_dacl_sacl.rs
@@ -1,7 +1,8 @@
+use windows_sys::Win32::Security::ACL;
+
 use crate::{wrappers, Acl, SecurityDescriptor};
 use std::io;
 use std::ptr::null_mut;
-use winapi::um::winnt::PACL;
 
 macro_rules! get_security_descriptor_acl {
     ($f:ident; msdn: $msdn:expr) => {
@@ -12,11 +13,11 @@ macro_rules! get_security_descriptor_acl {
         #[allow(non_snake_case)]
         pub fn $f(sd: &SecurityDescriptor) -> io::Result<Option<&Acl>> {
             let mut present = 0i32;
-            let mut acl_ptr: PACL = null_mut();
+            let mut acl_ptr: *mut ACL = null_mut();
             let mut defaulted = 0i32;
 
             let result = unsafe {
-                winapi::um::securitybaseapi::$f(
+                windows_sys::Win32::Security::$f(
                     sd as *const _ as *mut _,
                     &mut present,
                     &mut acl_ptr,

--- a/src/wrappers/get_security_descriptor_owner_group.rs
+++ b/src/wrappers/get_security_descriptor_owner_group.rs
@@ -1,7 +1,7 @@
 use crate::{SecurityDescriptor, Sid};
+use std::ffi::c_void;
 use std::io;
 use std::ptr::{null_mut, NonNull};
-use winapi::ctypes::c_void;
 
 /// Wraps [`GetSecurityDescriptorOwner`](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-getsecuritydescriptorowner)
 #[allow(non_snake_case)]
@@ -10,7 +10,7 @@ pub fn GetSecurityDescriptorOwner(sd: &SecurityDescriptor) -> io::Result<Option<
     let mut _sid_default: i32 = 0;
 
     let result = unsafe {
-        winapi::um::securitybaseapi::GetSecurityDescriptorOwner(
+        windows_sys::Win32::Security::GetSecurityDescriptorOwner(
             sd as *const _ as *mut _,
             &mut sid_ptr,
             &mut _sid_default,
@@ -32,7 +32,7 @@ pub fn GetSecurityDescriptorGroup(sd: &SecurityDescriptor) -> io::Result<Option<
     let mut _sid_default: i32 = 0;
 
     let result = unsafe {
-        winapi::um::securitybaseapi::GetSecurityDescriptorGroup(
+        windows_sys::Win32::Security::GetSecurityDescriptorGroup(
             sd as *const _ as *mut _,
             &mut sid_ptr,
             &mut _sid_default,

--- a/src/wrappers/get_security_info.rs
+++ b/src/wrappers/get_security_info.rs
@@ -1,9 +1,10 @@
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+
 use crate::constants::{SeObjectType, SecurityInformation};
 use crate::{LocalBox, SecurityDescriptor};
 use std::io;
 use std::os::windows::io::AsRawHandle;
 use std::ptr::{null_mut, NonNull};
-use winapi::shared::winerror::ERROR_SUCCESS;
 
 /// Wraps [`GetSecurityInfo`](https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-getsecurityinfo)
 ///
@@ -19,9 +20,9 @@ pub fn GetSecurityInfo<H: AsRawHandle>(
     let mut sd = null_mut();
 
     let result_code = unsafe {
-        winapi::um::aclapi::GetSecurityInfo(
-            handle.as_raw_handle() as *mut _,
-            obj_type as u32,
+        windows_sys::Win32::Security::Authorization::GetSecurityInfo(
+            handle.as_raw_handle() as isize,
+            obj_type as _,
             sec_info.bits(),
             null_mut(),
             null_mut(),

--- a/src/wrappers/get_sid_identifier_authority.rs
+++ b/src/wrappers/get_sid_identifier_authority.rs
@@ -13,7 +13,7 @@ use crate::Sid;
 #[allow(non_snake_case)]
 pub fn GetSidIdentifierAuthority(sid: &Sid) -> &[u8; 6] {
     let ptr = unsafe {
-        &*winapi::um::securitybaseapi::GetSidIdentifierAuthority(sid as *const _ as *mut _)
+        &*windows_sys::Win32::Security::GetSidIdentifierAuthority(sid as *const _ as *mut _)
     };
     &ptr.Value
 }

--- a/src/wrappers/get_sid_length_required.rs
+++ b/src/wrappers/get_sid_length_required.rs
@@ -11,7 +11,7 @@
 pub fn GetSidLengthRequired(sub_auth_count: u8) -> usize {
     // Assumptions:
     // - None. The function is guaranteed by the WinAPI not to fail
-    unsafe { winapi::um::securitybaseapi::GetSidLengthRequired(sub_auth_count) as usize }
+    unsafe { windows_sys::Win32::Security::GetSidLengthRequired(sub_auth_count) as usize }
 }
 
 #[cfg(test)]

--- a/src/wrappers/get_sid_sub_authority.rs
+++ b/src/wrappers/get_sid_sub_authority.rs
@@ -25,7 +25,7 @@ use crate::Sid;
 /// ```
 #[allow(non_snake_case)]
 pub unsafe fn GetSidSubAuthority(sid: &Sid, sub_auth: u8) -> *mut u32 {
-    winapi::um::securitybaseapi::GetSidSubAuthority(sid as *const _ as *mut _, sub_auth as u32)
+    windows_sys::Win32::Security::GetSidSubAuthority(sid as *const _ as *mut _, sub_auth as u32)
 }
 
 /// Wraps [`GetSidSubAuthority`](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-getsidsubauthority)

--- a/src/wrappers/get_sid_sub_authority_count.rs
+++ b/src/wrappers/get_sid_sub_authority_count.rs
@@ -13,5 +13,5 @@ use crate::Sid;
 /// ```
 #[allow(non_snake_case)]
 pub fn GetSidSubAuthorityCount(sid: &Sid) -> u8 {
-    unsafe { *winapi::um::securitybaseapi::GetSidSubAuthorityCount(sid as *const _ as *mut _) }
+    unsafe { *windows_sys::Win32::Security::GetSidSubAuthorityCount(sid as *const _ as *mut _) }
 }

--- a/src/wrappers/get_trustee_form.rs
+++ b/src/wrappers/get_trustee_form.rs
@@ -5,8 +5,10 @@ use crate::Trustee;
 ///
 /// If the form value is not recognized, returns `Err` with the raw value.
 #[allow(non_snake_case)]
-pub fn GetTrusteeForm(trustee: &Trustee) -> Result<TrusteeForm, u32> {
-    let form = unsafe { winapi::um::aclapi::GetTrusteeFormW(trustee.as_ptr() as *mut _) };
+pub fn GetTrusteeForm(trustee: &Trustee) -> Result<TrusteeForm, i32> {
+    let form = unsafe {
+        windows_sys::Win32::Security::Authorization::GetTrusteeFormW(trustee.as_ptr() as *mut _)
+    };
 
     TrusteeForm::from_raw(form).ok_or(form)
 }

--- a/src/wrappers/get_trustee_name.rs
+++ b/src/wrappers/get_trustee_name.rs
@@ -6,7 +6,7 @@ use std::ffi::OsString;
 #[allow(non_snake_case)]
 pub fn GetTrusteeName(trustee: &Trustee) -> OsString {
     unsafe {
-        let ptr = winapi::um::aclapi::GetTrusteeNameW(trustee.as_ptr() as *mut _);
+        let ptr = windows_sys::Win32::Security::Authorization::GetTrusteeNameW(trustee.as_ptr());
         let len = search_buffer(&0, ptr);
         let buf = std::slice::from_raw_parts(ptr, len);
 

--- a/src/wrappers/get_windows_account_domain_sid.rs
+++ b/src/wrappers/get_windows_account_domain_sid.rs
@@ -1,6 +1,7 @@
+use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+
 use crate::{wrappers, LocalBox, Sid};
 use std::io;
-use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
 
 /// Wraps [`GetWindowsAccountDomainSid`](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-getwindowsaccountdomainsid)
 #[allow(non_snake_case)]
@@ -14,7 +15,7 @@ pub fn GetWindowsAccountDomainSid(sid: &Sid) -> io::Result<LocalBox<Sid>> {
         buffer = vec![0; len as usize];
 
         let result = unsafe {
-            winapi::um::securitybaseapi::GetWindowsAccountDomainSid(
+            windows_sys::Win32::Security::GetWindowsAccountDomainSid(
                 sid as *const _ as *mut _,
                 buffer.as_mut_ptr() as *mut _,
                 &mut len,
@@ -43,10 +44,11 @@ pub fn GetWindowsAccountDomainSid(sid: &Sid) -> io::Result<LocalBox<Sid>> {
 
 #[cfg(test)]
 mod test {
+    use windows_sys::Win32::Foundation::ERROR_NON_ACCOUNT_SID;
+
     use super::*;
 
     use crate::utilities;
-    use winapi::shared::winerror::ERROR_NON_ACCOUNT_SID;
 
     #[test]
     fn current_process_has_domain() {
@@ -57,7 +59,7 @@ mod test {
     fn well_known_sid_has_no_domain() {
         assert_eq!(
             GetWindowsAccountDomainSid(
-                &Sid::well_known_sid(winapi::um::winnt::WinWorldSid).unwrap()
+                &Sid::well_known_sid(windows_sys::Win32::Security::WinWorldSid).unwrap()
             )
             .unwrap_err()
             .raw_os_error(),

--- a/src/wrappers/is_valid_acl.rs
+++ b/src/wrappers/is_valid_acl.rs
@@ -3,5 +3,5 @@ use crate::Acl;
 /// Wraps [`IsValidAcl`](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-isvalidacl)
 #[allow(non_snake_case)]
 pub fn IsValidAcl(acl: &Acl) -> bool {
-    (unsafe { winapi::um::securitybaseapi::IsValidAcl(acl as *const _ as *mut _) }) != 0
+    (unsafe { windows_sys::Win32::Security::IsValidAcl(acl as *const _ as *mut _) }) != 0
 }

--- a/src/wrappers/is_valid_security_descriptor.rs
+++ b/src/wrappers/is_valid_security_descriptor.rs
@@ -3,6 +3,6 @@ use crate::SecurityDescriptor;
 /// Wraps [`IsValidSecurityDescriptor`](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-isvalidsecuritydescriptor)
 #[allow(non_snake_case)]
 pub fn IsValidSecurityDescriptor(sd: &SecurityDescriptor) -> bool {
-    (unsafe { winapi::um::securitybaseapi::IsValidSecurityDescriptor(sd as *const _ as *mut _) })
+    (unsafe { windows_sys::Win32::Security::IsValidSecurityDescriptor(sd as *const _ as *mut _) })
         != 0
 }

--- a/src/wrappers/is_valid_sid.rs
+++ b/src/wrappers/is_valid_sid.rs
@@ -3,5 +3,5 @@ use crate::Sid;
 /// Wraps [`IsValidSid`](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-isvalidsid)
 #[allow(non_snake_case)]
 pub fn IsValidSid(sid: &Sid) -> bool {
-    (unsafe { winapi::um::securitybaseapi::IsValidSid(sid as *const _ as *mut _) }) != 0
+    (unsafe { windows_sys::Win32::Security::IsValidSid(sid as *const _ as *mut _) }) != 0
 }

--- a/src/wrappers/lookup_account_name.rs
+++ b/src/wrappers/lookup_account_name.rs
@@ -4,10 +4,7 @@ use std::{
     ptr::null,
 };
 
-use winapi::um::{
-    winbase::LookupAccountNameW,
-    winnt::{SID_NAME_USE, WCHAR},
-};
+use windows_sys::Win32::Security::{LookupAccountNameW, SID_NAME_USE};
 
 use crate::{
     constants::SidNameUse,
@@ -32,9 +29,11 @@ const MAX_RETRIES: usize = 5;
 /// # use windows_permissions::Sid;
 /// # use std::ffi::OsStr;
 /// #
+/// use windows_sys::Win32::Security::WinWorldSid;
+///
 /// // A well-known SID
 /// let (sid, _, name_use) = LookupAccountName(Option::<&OsStr>::None, "Everyone").unwrap();
-/// let win_world_sid = Sid::well_known_sid(winapi::um::winnt::WinWorldSid).unwrap();
+/// let win_world_sid = Sid::well_known_sid(WinWorldSid).unwrap();
 ///
 /// assert_eq!(Box::as_ref(&sid), win_world_sid.as_ref());
 /// assert_eq!(name_use, SidNameUse::SidTypeWellKnownGroup);
@@ -46,7 +45,7 @@ pub fn LookupAccountName(
 ) -> io::Result<(Box<Sid>, OsString, SidNameUse)> {
     // Buffers to hold the SID itself, the DOM name, and the SID name use
     let mut sid_buf: Vec<u8> = vec![0; BUFFER_SIZE];
-    let mut ref_dom_name_buf: Vec<WCHAR> = vec![0; BUFFER_SIZE];
+    let mut ref_dom_name_buf: Vec<u16> = vec![0; BUFFER_SIZE];
     let mut sid_name_use: SID_NAME_USE = 0;
 
     // Convert the system name and account name into buffers

--- a/src/wrappers/lookup_account_sid.rs
+++ b/src/wrappers/lookup_account_sid.rs
@@ -12,7 +12,7 @@ const BUFFER_SIZE: u32 = 256;
 ///
 /// ```
 /// use windows_permissions::{Sid, LocalBox, wrappers::LookupAccountSid};
-/// use winapi::um::winnt::WinBuiltinAdministratorsSid;
+/// use windows_sys::Win32::Security::WinBuiltinAdministratorsSid;
 ///
 /// let sid = Sid::well_known_sid(WinBuiltinAdministratorsSid).unwrap();
 /// let (name, domain) = LookupAccountSid(&sid).unwrap();
@@ -32,10 +32,10 @@ pub fn LookupAccountSid(sid: &Sid) -> Result<(OsString, OsString), io::Error> {
         let mut name: Vec<u16> = vec![0; name_size as usize];
         let mut dom: Vec<u16> = vec![0; dom_size as usize];
 
-        let mut name_use: u32 = 0;
+        let mut name_use = 0;
 
         let result = unsafe {
-            winapi::um::winbase::LookupAccountSidW(
+            windows_sys::Win32::Security::LookupAccountSidW(
                 null(),
                 sid as *const Sid as *mut _,
                 name.as_mut_ptr(),

--- a/src/wrappers/mod.rs
+++ b/src/wrappers/mod.rs
@@ -82,11 +82,12 @@ pub use set_security_info::SetSecurityInfo;
 
 #[cfg(test)]
 mod test {
+    use windows_sys::Win32::Security::{WinCapabilityMusicLibrarySid, WinLocalSid, WinWorldSid};
+
     use super::*;
 
     use crate::Sid;
     use std::ffi::OsString;
-    use winapi::um::winnt::{WinCapabilityMusicLibrarySid, WinLocalSid, WinWorldSid};
 
     #[test]
     fn construct_and_read_sids() {

--- a/src/wrappers/set_named_security_info.rs
+++ b/src/wrappers/set_named_security_info.rs
@@ -1,9 +1,10 @@
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+
 use crate::constants::{SeObjectType, SecurityInformation};
 use crate::utilities::{buf_from_os, ptr_from_opt};
 use crate::{Acl, Sid};
 use std::ffi::OsStr;
 use std::io;
-use winapi::shared::winerror::ERROR_SUCCESS;
 
 /// Wraps [`SetNamedSecurityInfoW`](https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setnamedsecurityinfow)
 #[allow(non_snake_case)]
@@ -19,9 +20,9 @@ pub fn SetNamedSecurityInfo<S: AsRef<OsStr> + ?Sized>(
     let name = buf_from_os(name);
 
     let result_code = unsafe {
-        winapi::um::aclapi::SetNamedSecurityInfoW(
+        windows_sys::Win32::Security::Authorization::SetNamedSecurityInfoW(
             name.as_ptr() as *mut _,
-            obj_type as u32,
+            obj_type as _,
             sec_info.bits(),
             ptr_from_opt(owner) as *mut _,
             ptr_from_opt(group) as *mut _,

--- a/src/wrappers/set_security_info.rs
+++ b/src/wrappers/set_security_info.rs
@@ -1,9 +1,10 @@
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+
 use crate::constants::{SeObjectType, SecurityInformation};
 use crate::utilities::ptr_from_opt;
 use crate::{Acl, Sid};
 use std::io;
 use std::os::windows::io::AsRawHandle;
-use winapi::shared::winerror::ERROR_SUCCESS;
 
 /// Wraps [`SetSecurityInfo`](https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setsecurityinfo)
 ///
@@ -20,9 +21,9 @@ pub fn SetSecurityInfo<H: AsRawHandle>(
     sacl: Option<&Acl>,
 ) -> io::Result<()> {
     let result_code = unsafe {
-        winapi::um::aclapi::SetSecurityInfo(
-            handle.as_raw_handle(),
-            obj_type as u32,
+        windows_sys::Win32::Security::Authorization::SetSecurityInfo(
+            handle.as_raw_handle() as isize,
+            obj_type as _,
             sec_info.bits(),
             ptr_from_opt(owner) as *mut _,
             ptr_from_opt(group) as *mut _,


### PR DESCRIPTION
`windows-sys` (and `windows`) are crates for bindings on Windows API officially supported by Microsoft. They are replacing `winapi` in many crates, and it would be nice to migrate this great project too :)

The differences in the API call are minimal. The other differences are mainly in the type used for constants, which can vary between i32 and u32, and is often not the same as the winapi one.